### PR TITLE
pass specified hostname to remote update command

### DIFF
--- a/bin/dotsync
+++ b/bin/dotsync
@@ -252,7 +252,7 @@ function rsyncremote()
     if [[ "$2" == "init" || "$2" == "push" ]]; then
       echo "*** Syncing $host with $DOTFILES using rsync ***"
       rsync -azRp $RSYNCOPT --delete --delete-excluded --exclude-from=.rsyncignore . $host:$DOTFILES/
-      ssh $host "$REMOTEDSPATH/dotsync -L $DOTSYNCOPT && \
+      ssh $host "HOSTNAME=$host $REMOTEDSPATH/dotsync -L $DOTSYNCOPT && \
         if [[ -d $DOTFILES/.git ]]; then rm -rf $DOTFILES/.git/; fi && \
           echo "$host from $HOSTNAME" > $DOTFILES/.rsync"
       echo


### PR DESCRIPTION
Before this change, remote update which is triggered after rsync used
actual hostname on the remote machine.
With this change, when remote update runs, it passes locally specified
hostname to remote command. So that, remote server name doesn't need to
match with the actual remote server name.

Issue: #1
