### PR TITLE
Tweaks to submodule handling

### DIFF
--- a/bin/dotsync
+++ b/bin/dotsync
@@ -358,8 +358,10 @@ function gitpull()
   if [[ "$1" == "all" ]]; then
     cd $HOME/$DOTFILES
     echo "*** Pulling latest changes for submodules ***"
+    # Required if a submodule origin changed
+    git submodule $GITSUBOPT sync
     git submodule $GITSUBOPT foreach --recursive git fetch
-    git submodule $GITSUBOPT foreach --recursive git submodule update
+    git submodule $GITSUBOPT update --init --recursive
   fi
   cd
 }


### PR DESCRIPTION
I added "git submodule sync"  (Specifically this deals with origin URL changes, I had to add this because I switched from using the dotphiles github to my fork).

I changed the "submodule update".  I think the previous one was just broken, it didn't do anything inside a foreach.

I added an --init to the "submodule update", which is nothing if it's already done but will properly initialize new modules.
