### PR TITLE
abort

### DIFF
--- a/bin/dotsync
+++ b/bin/dotsync
@@ -44,6 +44,9 @@ ALLOPT=""
 REMOTEDSPATH="$DOTFILES/dotsync/bin"
 REMOTEBACKUPDIR="\$HOME/.backup/`echo $DOTFILES |sed s/^\.//g`"
 
+# Exit immediately on SIGINT
+trap exit SIGINT
+
 function checknotroot()
 {
   if [[ $USER == "root" ]]; then


### PR DESCRIPTION
Added an exit  trap on SIGINT so that CTRL-C when running dotsync stops it right away.

Without this, an interrupt signal (during a remote call) will stop the remote process only.  Then it goes on and does the next one.  This trap causes it to stop altogether.
