### PR TITLE
Create the missing directory when symlink dotfiles into the destination.

### DIFF
--- a/bin/dotsync
+++ b/bin/dotsync
@@ -124,6 +124,7 @@ getrealdotfile()
   fi
 
   DOTFILE="$HOME/$DSTFILE"
+  DOTFILE_DIR=$(dirname "${DOTFILE}")
 }
 
 initlocal()
@@ -169,6 +170,7 @@ symlink()
       rm -f "$DOTFILE"
       ln -s "$REALFILE" "$DOTFILE"
     else
+      mkdir -p "$DOTFILE_DIR"
       ln -s "$REALFILE" "$DOTFILE"
     fi
 


### PR DESCRIPTION
When initially install and create symlinks, it fails if the destination directory does not exist. This change will automatically create the missing directory.